### PR TITLE
Fix S3 metadata for PutObjectRequest

### DIFF
--- a/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
+++ b/aws-cpp-sdk-s3/source/model/PutObjectRequest.cpp
@@ -146,7 +146,7 @@ Aws::Http::HeaderValueCollection PutObjectRequest::GetRequestSpecificHeaders() c
    {
      ss << "x-amz-meta-" << item.first;
      headers.insert(Aws::Http::HeaderValuePair(ss.str(), item.second));
-     ss.str();
+     ss.str("");
    }
   }
 


### PR DESCRIPTION
stringstream wasn't cleared for subsequent metadata keys