### PR TITLE
Fix crash in CurlHttpClient when request times out.

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -242,7 +242,9 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(HttpRequest& request, 
 
         m_curlHandleContainer.ReleaseCurlHandle(connectionHandle);
         //go ahead and flush the response body stream
-        response->GetResponseBody().flush();
+        if (response) {
+            response->GetResponseBody().flush();
+        }
     }
 
     if (headers)


### PR DESCRIPTION
Integration test was crashing with a segfault when the connection timed out.
Reason was that the response was nulled in this case but still dereferenced to flush it.