### PR TITLE
Fixed codegen for lists with locationNames.

### DIFF
--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/queryxml/QueryRequestSource.vm
@@ -54,7 +54,14 @@ Aws::String ${typeInfo.className}::SerializePayload() const
 #set($location = $member.key)
 #end
 #else
+#if($member.value.locationName)
+#set($location = $member.value.locationName)
+#else
 #set($location = $member.key + ".member")
+#end
+#if($metadata.protocol == "ec2")
+#set($location = $CppViewHelper.capitalizeFirstChar($location))
+#end
 #end
 #if($member.value.shape.listMember.shape.structure)
   ${spaces}  item.OutputToStream(ss, "${location}.", ${varName}Count, "");

--- a/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersDeserializeXml.vm
+++ b/code-generation/generator/src/main/resources/com/amazonaws/util/awsclientgenerator/velocity/cpp/xml/ModelClassMembersDeserializeXml.vm
@@ -29,7 +29,11 @@
 #set($listVarName = $CppViewHelper.computeVariableName($memberName) + "Member")
 #set($listMemberName = "member")
 #end##location specified in model
+#if($member.locationName)##location specified
+    XmlNode ${lowerCaseVarName}Node = resultNode.FirstChild("${member.locationName}");
+#else##no location specified
     XmlNode ${lowerCaseVarName}Node = resultNode.FirstChild("${memberName}");
+#end##
 #end##list member uses flattened serialization
 #elseif($member.shape.map)##member is a map
 #if($member.locationName)##member uses location for serialization


### PR DESCRIPTION
This primarily impacts the EC2 APIs.
See issue #70

This fixes enough of the API to get it working.  There are still a few places I found that don't work, for example the Filter on DescribeInstances still doesn't serialize correctly, but InstanceIds does now.