### PR TITLE
Add ability to set metadata for object uploads in transfer library.

### DIFF
--- a/aws-cpp-sdk-transfer/include/aws/transfer/TransferClient.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/TransferClient.h
@@ -61,10 +61,13 @@ class AWS_TRANSFER_API TransferClient
         TransferClient(const std::shared_ptr<Aws::S3::S3Client>& s3Client, const TransferClientConfiguration& config);
         ~TransferClient();
 
-        // Single entry point for attempting an upload - attempting to create an existing bucket won't hurt anything but will affect performance
+        // Entry point for attempting an upload - attempting to create an existing bucket won't hurt anything but will affect performance
         // unnecessarily as the request waits for S3 to propagate the bucket
         // All queries about the upload after this point can be found in UploadFileRequest's interface
         std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, bool createBucket = false, bool doConsistencyChecks = false);
+        // Entry point similar to above but with metadata specified
+        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket = false, bool doConsistencyChecks = false);
+        std::shared_ptr<UploadFileRequest> UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket = false, bool doConsistencyChecks = false);
 
         // User requested upload cancels should go through here
         void CancelUpload(std::shared_ptr<UploadFileRequest>& fileRequest) const;
@@ -84,7 +87,7 @@ class AWS_TRANSFER_API TransferClient
     private:
 
         void UploadFileInternal(std::shared_ptr<UploadFileRequest>& fileRequest);
-  
+
         void ProcessSingleBuffer(std::shared_ptr<UploadFileRequest>& request, const std::shared_ptr<UploadBuffer>& buffer);
 
         void CancelUploadInternal(std::shared_ptr<UploadFileRequest>& fileRequest) const;

--- a/aws-cpp-sdk-transfer/include/aws/transfer/UploadFileRequest.h
+++ b/aws-cpp-sdk-transfer/include/aws/transfer/UploadFileRequest.h
@@ -76,6 +76,14 @@ public:
 class AWS_TRANSFER_API UploadFileRequest : public S3FileRequest, public std::enable_shared_from_this<UploadFileRequest>
 {
 public:
+    UploadFileRequest(const Aws::String& fileName,
+                      const Aws::String& bucketName,
+                      const Aws::String& keyName,
+                      const Aws::String& contentType,
+                      Aws::Map<Aws::String, Aws::String>&& metadata,
+                      const std::shared_ptr<Aws::S3::S3Client>& s3Client,
+                      bool createBucket,
+                      bool doConsistencyChecks);
     UploadFileRequest(const Aws::String& fileName, 
                       const Aws::String& bucketName, 
                       const Aws::String& keyName, 
@@ -83,7 +91,15 @@ public:
                       const std::shared_ptr<Aws::S3::S3Client>& s3Client, 
                       bool createBucket,
                       bool doConsistencyChecks);
-    ~UploadFileRequest();
+    UploadFileRequest(const Aws::String& fileName,
+                      const Aws::String& bucketName,
+                      const Aws::String& keyName,
+                      const Aws::String& contentType,
+                      const Aws::Map<Aws::String, Aws::String>& metadata,
+                      const std::shared_ptr<Aws::S3::S3Client>& s3Client,
+                      bool createBucket,
+                      bool doConsistencyChecks);
+    virtual ~UploadFileRequest();
 
     // How many parts have we at least begun to upload
     uint32_t GetPartCount() const;
@@ -255,6 +271,7 @@ private:
     Aws::List<std::shared_ptr<UploadBuffer> > m_buffersReady;
 
     Aws::String m_contentType;
+    Aws::Map<Aws::String, Aws::String> m_metadata;
     Aws::String m_uploadId;
     uint32_t m_createMultipartRetries;
     uint32_t m_createBucketRetries;

--- a/aws-cpp-sdk-transfer/source/transfer/TransferClient.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/TransferClient.cpp
@@ -74,6 +74,24 @@ std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String&
     return request;
 }
 
+std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, const Aws::Map<Aws::String, Aws::String>& metadata, bool createBucket, bool doConsistencyChecks)
+{
+    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, metadata, m_s3Client, createBucket, doConsistencyChecks);
+
+    UploadFileInternal(request);
+
+    return request;
+}
+
+std::shared_ptr<UploadFileRequest> TransferClient::UploadFile(const Aws::String& fileName, const Aws::String& bucketName, const Aws::String& keyName, const Aws::String& contentType, Aws::Map<Aws::String, Aws::String>&& metadata, bool createBucket, bool doConsistencyChecks)
+{
+    auto request = Aws::MakeShared<UploadFileRequest>(ALLOCATION_TAG, fileName, bucketName, keyName, contentType, std::move(metadata), m_s3Client, createBucket, doConsistencyChecks);
+
+    UploadFileInternal(request);
+
+    return request;
+}
+
 void TransferClient::UploadFileInternal(std::shared_ptr<UploadFileRequest>& request) 
 {
 


### PR DESCRIPTION
Adding the ability for users of TransferClient to set metadata of objects they are uploading. Let me know if there's anything that needs to change with the new public methods I added here.