### PR TITLE
Reset stream buffer position before retrying part transfer

### DIFF
--- a/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
+++ b/aws-cpp-sdk-transfer/source/transfer/UploadFileRequest.cpp
@@ -680,6 +680,7 @@ void UploadFileRequest::HandlePartFailure(const Aws::S3::Model::UploadPartOutcom
 void UploadFileRequest::DoRetry(PartRequestRecord& partRequest)
 {
     ++m_totalPartRetries;
+    partRequest.m_partRequest.GetBody()->seekg(0);
     RequestPart(partRequest.m_partRequest.GetPartNumber());
 }
 


### PR DESCRIPTION
Right now, whenever a part fails, each retry attempt would produce the following error:
`RequestTimeout Message: Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.`
because there are no more bytes to read from the buffer to make up to the desired content length.

This fix would allow retry attempts to get through.
