### PR TITLE
Fix segfault in curl due to SIGALRM

### DIFF
--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
@@ -247,7 +247,6 @@ std::shared_ptr<HttpResponse> CurlHttpClient::MakeRequest(HttpRequest& request, 
                 response->SetContentType(contentType);
                 AWS_LOGSTREAM_DEBUG(CurlTag, "Returned content type " << contentType);
             }
-            curl_easy_reset(connectionHandle);
             AWS_LOGSTREAM_DEBUG(CurlTag, "Releasing curl handle " << connectionHandle);
         }
 


### PR DESCRIPTION
The curl options set by CurlHandleContainer::CheckAndGrowPool() were
being clobbered by CurlHttpClient::MakeRequest()'s call to
curl_easy_reset(). In particular, this made CURLOPT_NOSIGNAL revert to
0, causing random crashes in multithreaded applications.

The fix is to have CurlHandleContainer::AcquireCurlHandle() do the
curl_easy_reset() and option setting, ensuring a consistent handle
state.